### PR TITLE
[trivial] Skip Trivy in auctions dir

### DIFF
--- a/trivy.yaml
+++ b/trivy.yaml
@@ -1,0 +1,3 @@
+scan:
+  skip-dirs:
+    - auctions


### PR DESCRIPTION
(review requests added so you'd all be aware)

- Trivy started failing in this repo due to timeouts
- the `auctions` directory only contains JSON/CSV/MD files with data - no need to scan