### PR TITLE
Update activatingStakePmpeMult value to 0.2 [trivial]

### DIFF
--- a/auction-config.json
+++ b/auction-config.json
@@ -37,5 +37,5 @@
   "minimalCommission": -5.0,
   "bidTooLowPenaltyPermittedDeviationPmpe": 0.01,
   "bondRiskFeeMult": 0.2,
-  "activatingStakePmpeMult": 0.1
+  "activatingStakePmpeMult": 0.2
 }


### PR DESCRIPTION
The feature was launched with 0.1.  Next epoch we want to charge 0.2.  This change introduces the ramp-up.