### PR TITLE
[trivial] Fix epochs ordering in scheduler

### DIFF
--- a/.github/workflows/schedule-auction.yml
+++ b/.github/workflows/schedule-auction.yml
@@ -20,8 +20,8 @@ jobs:
           current_epoch=$(<<<"$epoch_info" jq '.result.epoch' -r)
           current_slot=$(<<<"$epoch_info" jq '.result.slotIndex' -r)
 
-          last_epoch_repo=$(find auctions -type d | sort -n | tail -1 | cut -d/ -f2 | cut -d. -f1)
-          last_epoch_pr=$(gh pr list --state open --json headRefName,isCrossRepository --jq '.[] | select(.isCrossRepository == false) | .headRefName' | grep auction/ | sort -n | tail -1 | cut -d/ -f2| cut -d. -f1)
+          last_epoch_repo=$(find auctions -type d | sort -V | tail -1 | cut -d/ -f2 | cut -d. -f1)
+          last_epoch_pr=$(gh pr list --state open --json headRefName,isCrossRepository --jq '.[] | select(.isCrossRepository == false) | .headRefName' | grep auction/ | sort -V | tail -1 | cut -d/ -f2| cut -d. -f1)
 
           echo "Epoch of the last auction in repo: $last_epoch_repo"
           echo "Epoch of the last auction in PR: $last_epoch_pr"


### PR DESCRIPTION
`-n` sort is broken by the `auctions` prefix which surfaced due to epoch reaching 1000

`-V` compares versions which is not really the case here but the logic matches what's needed precisely