### PR TITLE
[GEN-8966] Use an absolute path and explicit HOME for validator-manager

### DIFF
--- a/.github/workflows/apply-auction.yml
+++ b/.github/workflows/apply-auction.yml
@@ -64,18 +64,18 @@ jobs:
           SCORES_FILE: ${{ env.scores_file }}
           IMAGE_TAG: ${{ env.image_tag }}
         run: |
-          docker run --rm --user "$(id -u):$(id -g)" \
+          docker run --rm --user "$(id -u):$(id -g)" -e HOME=/ \
             -v /tmp/solana-config.yml:/.config/solana/cli/config.yml \
             -v /tmp/id.json:/.config/solana/id.json \
             -v "$SCORES_FILE:/scores.csv" \
             "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" \
-            ./validator-manager --print update-scores2 --scores-file /scores.csv
-          docker run --rm --user "$(id -u):$(id -g)" \
+            /usr/local/bin/validator-manager --print update-scores2 --scores-file /scores.csv
+          docker run --rm --user "$(id -u):$(id -g)" -e HOME=/ \
               -v /tmp/solana-config.yml:/.config/solana/cli/config.yml \
               -v /tmp/id.json:/.config/solana/id.json \
               -v "$SCORES_FILE:/scores.csv" \
             "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" \
-            ./validator-manager --simulate update-scores2 --scores-file /scores.csv
+            /usr/local/bin/validator-manager --simulate update-scores2 --scores-file /scores.csv
       - name: Update scores
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
@@ -86,12 +86,12 @@ jobs:
           set +e
           for i in {1..20}
           do
-            docker run --rm --user "$(id -u):$(id -g)" \
+            docker run --rm --user "$(id -u):$(id -g)" -e HOME=/ \
               -v /tmp/solana-config.yml:/.config/solana/cli/config.yml \
               -v /tmp/id.json:/.config/solana/id.json \
               -v "$SCORES_FILE:/scores.csv" \
               "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" \
-              ./validator-manager update-scores2 --scores-file /scores.csv --with-compute-unit-price 10 --sender-rpc-url https://tx-rpc.marinade.finance
+              /usr/local/bin/validator-manager update-scores2 --scores-file /scores.csv --with-compute-unit-price 10 --sender-rpc-url https://tx-rpc.marinade.finance
 
             status=$?
               if [[ $status -eq 0 ]]; then


### PR DESCRIPTION
Drops the workflow's dependency on the container image's `WORKDIR` and `HOME`, so the image can be rebuilt on a different base without changing this file. No behaviour change with the current image.

⚠️ Merge this before the image changes.